### PR TITLE
Change name of environment variable to define qzui port.

### DIFF
--- a/srv/src/main/java/qzui/AppServer.java
+++ b/srv/src/main/java/qzui/AppServer.java
@@ -16,7 +16,7 @@ public class AppServer {
     public static final String WEB_APP_LOCATION = "../ui/app";
 
     public static void main(String[] args) throws Exception {
-        int port = Integer.valueOf(Optional.fromNullable(System.getenv("PORT")).or("8080"));
+        int port = Integer.valueOf(Optional.fromNullable(System.getenv("QZUI_PORT")).or("8080"));
         WebServer server = new JettyWebServer(WEB_INF_LOCATION, WEB_APP_LOCATION, port, "0.0.0.0");
 
         /*


### PR DESCRIPTION
Because I need to launch qzui with restx shell on a different port that 8080, I would like to have an explicit name (not just "PORT") for my environment variable
