### PR TITLE
Body content type management and http authentication

### DIFF
--- a/srv/src/main/java/qzui/HttpJobDefinition.java
+++ b/srv/src/main/java/qzui/HttpJobDefinition.java
@@ -39,6 +39,7 @@ public class HttpJobDefinition extends AbstractJobDefinition {
         private String url;
         private String method = "POST";
         private String body;
+        private String contentType;
 
         public String getUrl() {
             return url;
@@ -50,6 +51,10 @@ public class HttpJobDefinition extends AbstractJobDefinition {
 
         public String getBody() {
             return body;
+        }
+
+        public String getContentType() {
+            return contentType;
         }
 
         public HttpJobDescriptor setBody(final String body) {
@@ -67,12 +72,18 @@ public class HttpJobDefinition extends AbstractJobDefinition {
             return this;
         }
 
+        public HttpJobDescriptor setContentType(final String contentType) {
+            this.contentType = contentType;
+            return this;
+        }
+
         @Override
         public JobDetail buildJobDetail() {
             JobDataMap dataMap = new JobDataMap(getData());
             dataMap.put("url", url);
             dataMap.put("method", method);
             dataMap.put("body", body);
+            dataMap.put("contentType", contentType);
             return newJob(HttpJob.class)
                     .withIdentity(getName(), getGroup())
                     .usingJobData(dataMap)
@@ -85,6 +96,7 @@ public class HttpJobDefinition extends AbstractJobDefinition {
                     "url='" + url + '\'' +
                     ", method='" + method + '\'' +
                     ", body='" + body + '\'' +
+                    ", contentType='" + contentType + '\'' +
                     '}';
         }
 
@@ -100,6 +112,10 @@ public class HttpJobDefinition extends AbstractJobDefinition {
             String body = "";
             if (!isNullOrEmpty(jobDataMap.getString("body"))) {
                 body = jobDataMap.getString("body");
+            }
+            String contentType = jobDataMap.getString("contentType");
+            if (!isNullOrEmpty(contentType)) {
+                request.contentType(contentType);
             }
             request.send(body);
 

--- a/srv/src/main/java/qzui/domain/AbstractJobDefinition.java
+++ b/srv/src/main/java/qzui/domain/AbstractJobDefinition.java
@@ -1,4 +1,4 @@
-package qzui;
+package qzui.domain;
 
 import org.quartz.JobDetail;
 import org.quartz.Trigger;

--- a/srv/src/main/java/qzui/domain/HttpJobDefinition.java
+++ b/srv/src/main/java/qzui/domain/HttpJobDefinition.java
@@ -40,6 +40,8 @@ public class HttpJobDefinition extends AbstractJobDefinition {
         private String method = "POST";
         private String body;
         private String contentType;
+        private String login;
+        private String pwdHash;
 
         public String getUrl() {
             return url;
@@ -55,6 +57,14 @@ public class HttpJobDefinition extends AbstractJobDefinition {
 
         public String getContentType() {
             return contentType;
+        }
+
+        public String getLogin() {
+            return login;
+        }
+
+        public String getPwdHash() {
+            return pwdHash;
         }
 
         public HttpJobDescriptor setBody(final String body) {
@@ -77,6 +87,16 @@ public class HttpJobDefinition extends AbstractJobDefinition {
             return this;
         }
 
+        public HttpJobDescriptor setPwdHash(final String pwdHash) {
+            this.pwdHash = pwdHash;
+            return this;
+        }
+
+        public HttpJobDescriptor setLogin(final String login) {
+            this.login = login;
+            return this;
+        }
+
         @Override
         public JobDetail buildJobDetail() {
             JobDataMap dataMap = new JobDataMap(getData());
@@ -84,6 +104,8 @@ public class HttpJobDefinition extends AbstractJobDefinition {
             dataMap.put("method", method);
             dataMap.put("body", body);
             dataMap.put("contentType", contentType);
+            dataMap.put("login", login);
+            dataMap.put("pwd", pwdHash);
             return newJob(HttpJob.class)
                     .withIdentity(getName(), getGroup())
                     .usingJobData(dataMap)
@@ -105,23 +127,40 @@ public class HttpJobDefinition extends AbstractJobDefinition {
     public static class HttpJob implements Job {
         @Override
         public void execute(JobExecutionContext context) throws JobExecutionException {
+
             JobDataMap jobDataMap = context.getJobDetail().getJobDataMap();
             String url = jobDataMap.getString("url");
             String method = jobDataMap.getString("method");
             HttpRequest request = new HttpRequest(url, method);
+
             String body = "";
             if (!isNullOrEmpty(jobDataMap.getString("body"))) {
                 body = jobDataMap.getString("body");
             }
+
+            setContentType(jobDataMap, request);
+            setCrendentials(jobDataMap, request);
+
+            request.send(body);
+            int code = request.code();
+            String responseBody = request.body();
+
+            logger.info("{} {} => {}\n{}", method, url, code, responseBody);
+        }
+
+        private void setCrendentials(JobDataMap jobDataMap, HttpRequest request) {
+            String login = jobDataMap.getString("login");
+            String pwd = jobDataMap.getString("pwd");
+            if (!isNullOrEmpty(login) && !isNullOrEmpty(pwd)) {
+                request.basic(login, pwd);
+            }
+        }
+
+        private void setContentType(JobDataMap jobDataMap, HttpRequest request) {
             String contentType = jobDataMap.getString("contentType");
             if (!isNullOrEmpty(contentType)) {
                 request.contentType(contentType);
             }
-            request.send(body);
-
-            int code = request.code();
-            String responseBody = request.body();
-            logger.info("{} {} => {}\n{}", method, url, code, responseBody);
         }
     }
 

--- a/srv/src/main/java/qzui/domain/HttpJobDefinition.java
+++ b/srv/src/main/java/qzui/domain/HttpJobDefinition.java
@@ -1,4 +1,4 @@
-package qzui;
+package qzui.domain;
 
 import com.github.kevinsawicki.http.HttpRequest;
 import org.quartz.*;

--- a/srv/src/main/java/qzui/domain/JobDefinition.java
+++ b/srv/src/main/java/qzui/domain/JobDefinition.java
@@ -1,4 +1,4 @@
-package qzui;
+package qzui.domain;
 
 import org.quartz.Job;
 import org.quartz.JobDetail;

--- a/srv/src/main/java/qzui/domain/JobDescriptor.java
+++ b/srv/src/main/java/qzui/domain/JobDescriptor.java
@@ -1,4 +1,4 @@
-package qzui;
+package qzui.domain;
 
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/srv/src/main/java/qzui/domain/LogJobDefinition.java
+++ b/srv/src/main/java/qzui/domain/LogJobDefinition.java
@@ -1,4 +1,4 @@
-package qzui;
+package qzui.domain;
 
 import org.quartz.*;
 import org.slf4j.Logger;

--- a/srv/src/main/java/qzui/domain/TriggerDescriptor.java
+++ b/srv/src/main/java/qzui/domain/TriggerDescriptor.java
@@ -1,4 +1,4 @@
-package qzui;
+package qzui.domain;
 
 import org.joda.time.DateTime;
 import org.quartz.Trigger;

--- a/srv/src/main/java/qzui/rest/JobResource.java
+++ b/srv/src/main/java/qzui/rest/JobResource.java
@@ -1,8 +1,10 @@
-package qzui;
+package qzui.rest;
 
 import com.google.common.base.Optional;
 import org.quartz.*;
 import org.quartz.impl.matchers.GroupMatcher;
+import qzui.domain.JobDefinition;
+import qzui.domain.JobDescriptor;
 import restx.annotations.DELETE;
 import restx.annotations.GET;
 import restx.annotations.POST;
@@ -10,7 +12,6 @@ import restx.annotations.RestxResource;
 import restx.factory.Component;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 /**


### PR DESCRIPTION
Concerns :
- Allows the job emitter to provide a body content-type which will be used during http request when a job is triggered (http jobs only)
- Allows the job emitter to provide credentials which will be used (as http basic authentication) during http request when a job is triggered (http jobs only)
- Better packages hierarchy
