### PR TITLE
Allows HTTP specific configuration (especially concerning HTTP jobs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ The basic UI is developed using AngularJS + TW Boostrap, check [ui/app](https://
 You can setup the quartz configuration as you like, following [Quartz documentation](http://quartz-scheduler.org/documentation/quartz-2.2.x/configuration/)
 We strongly recommend setting up a jobstore if you don't want to lose your jobs at each server restart.
 
+#### HTTP configuration
+
+Some specific HTTP configuration flags could be set. Two ways to do that :
+* Job specific : fill a configuration object (contained into a job descriptor)
+* Globally : define java properties set on Qzui runtime
+
+```
+-Dhttp.ssl.trustAllCerts=true -Dhttp.ssl.trustAllHosts=true
+```
+
+Note that the specific configuration overrides the global one.
+
 ## Usage
 
 When the server is launched, open your browser at http://localhost:8080/ and you will get the list of jobs.
@@ -129,6 +141,23 @@ Note that jobs MUST have unique names.
   "triggers": [
         {"cron":"0/2 * * * * ?"}
   ]
+}
+```
+
+#### HTTP Job, scheduled using cron syntax, with HTTP specific configuration
+```
+{
+  "type":"http",
+  "name":"google-humans",
+  "method":"GET",
+  "url":"http://www.google.com/humans.txt",
+  "triggers": [
+        {"cron":"0/2 * * * * ?"}
+  ],
+  "httpConfiguration": {
+        "trustAllHosts": true,
+        "trustAllCerts": true,
+  }
 }
 ```
 

--- a/srv/src/main/java/qzui/domain/HttpConfiguration.java
+++ b/srv/src/main/java/qzui/domain/HttpConfiguration.java
@@ -1,0 +1,29 @@
+package qzui.domain;
+
+public class HttpConfiguration {
+
+    public static final String TRUST_ALL_CERTS = "http.ssl.trustAllCerts";
+    public static final String TRUST_ALL_HOSTS = "http.ssl.trustAllHosts";
+
+    private boolean trustAllCerts;
+
+    private boolean trustAllHosts;
+
+    public boolean isTrustAllCerts() {
+        return trustAllCerts;
+    }
+
+    public boolean isTrustAllHosts() {
+        return trustAllHosts;
+    }
+
+    public HttpConfiguration setTrustAllCerts(final boolean trustAllCerts) {
+        this.trustAllCerts = trustAllCerts;
+        return this;
+    }
+
+    public HttpConfiguration setTrustAllHosts(final boolean trustAllHosts) {
+        this.trustAllHosts = trustAllHosts;
+        return this;
+    }
+}

--- a/srv/src/main/java/qzui/domain/HttpConfiguration.java
+++ b/srv/src/main/java/qzui/domain/HttpConfiguration.java
@@ -2,8 +2,11 @@ package qzui.domain;
 
 public class HttpConfiguration {
 
-    public static final String TRUST_ALL_CERTS = "http.ssl.trustAllCerts";
-    public static final String TRUST_ALL_HOSTS = "http.ssl.trustAllHosts";
+    public static final String TRUST_ALL_CERTS_PROPERTY = "http.ssl.trustAllCerts";
+    public static final String TRUST_ALL_HOSTS_PROPERTY = "http.ssl.trustAllHosts";
+
+    public static final String TRUST_ALL_CERTS_FIELD = "httpSSLTrustAllCerts";
+    public static final String TRUST_ALL_HOSTS_FIELD = "httpSSLTrustAllHosts";
 
     private boolean trustAllCerts;
 

--- a/srv/src/main/java/qzui/domain/HttpJobDefinition.java
+++ b/srv/src/main/java/qzui/domain/HttpJobDefinition.java
@@ -1,6 +1,7 @@
 package qzui.domain;
 
 import com.github.kevinsawicki.http.HttpRequest;
+import com.google.common.base.Optional;
 import org.quartz.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +18,7 @@ import static org.quartz.JobBuilder.newJob;
  */
 @Component
 public class HttpJobDefinition extends AbstractJobDefinition {
+
     private static final Logger logger = LoggerFactory.getLogger(HttpJobDefinition.class);
 
     @Override
@@ -42,6 +44,8 @@ public class HttpJobDefinition extends AbstractJobDefinition {
         private String contentType;
         private String login;
         private String pwdHash;
+
+        private HttpConfiguration httpConfiguration;
 
         public String getUrl() {
             return url;
@@ -97,8 +101,18 @@ public class HttpJobDefinition extends AbstractJobDefinition {
             return this;
         }
 
+        public HttpConfiguration getHttpConfiguration() {
+            return httpConfiguration;
+        }
+
+        public HttpJobDescriptor setHttpConfiguration(final HttpConfiguration httpConfiguration) {
+            this.httpConfiguration = httpConfiguration;
+            return this;
+        }
+
         @Override
         public JobDetail buildJobDetail() {
+
             JobDataMap dataMap = new JobDataMap(getData());
             dataMap.put("url", url);
             dataMap.put("method", method);
@@ -106,10 +120,27 @@ public class HttpJobDefinition extends AbstractJobDefinition {
             dataMap.put("contentType", contentType);
             dataMap.put("login", login);
             dataMap.put("pwd", pwdHash);
+
+            configure(dataMap);
+
             return newJob(HttpJob.class)
                     .withIdentity(getName(), getGroup())
                     .usingJobData(dataMap)
                     .build();
+        }
+
+        private void configure(JobDataMap dataMap) {
+            Optional<String> trustAllCerts;
+            Optional<String> trustAllHosts;
+            if (getHttpConfiguration() == null) {
+                trustAllCerts = Optional.fromNullable(System.getProperty(HttpConfiguration.TRUST_ALL_CERTS));
+                trustAllHosts = Optional.fromNullable(System.getProperty(HttpConfiguration.TRUST_ALL_HOSTS));
+            } else {
+                trustAllCerts = Optional.of(Boolean.toString(getHttpConfiguration().isTrustAllCerts()));
+                trustAllHosts = Optional.of(Boolean.toString(getHttpConfiguration().isTrustAllHosts()));
+            }
+            dataMap.put(HttpConfiguration.TRUST_ALL_CERTS, trustAllCerts.or(Boolean.toString(false)));
+            dataMap.put(HttpConfiguration.TRUST_ALL_HOSTS, trustAllHosts.or(Boolean.toString(false)));
         }
 
         @Override
@@ -125,6 +156,7 @@ public class HttpJobDefinition extends AbstractJobDefinition {
     }
 
     public static class HttpJob implements Job {
+
         @Override
         public void execute(JobExecutionContext context) throws JobExecutionException {
 
@@ -140,12 +172,22 @@ public class HttpJobDefinition extends AbstractJobDefinition {
 
             setContentType(jobDataMap, request);
             setCrendentials(jobDataMap, request);
+            setSecurityParams(jobDataMap, request);
 
             request.send(body);
             int code = request.code();
             String responseBody = request.body();
 
             logger.info("{} {} => {}\n{}", method, url, code, responseBody);
+        }
+
+        private void setSecurityParams(JobDataMap jobDataMap, HttpRequest request) {
+            if (jobDataMap.getBooleanFromString(HttpConfiguration.TRUST_ALL_HOSTS)) {
+                request.trustAllHosts();
+            }
+            if (jobDataMap.getBooleanFromString(HttpConfiguration.TRUST_ALL_CERTS)) {
+                request.trustAllCerts();
+            }
         }
 
         private void setCrendentials(JobDataMap jobDataMap, HttpRequest request) {

--- a/srv/src/main/java/qzui/domain/HttpJobDefinition.java
+++ b/srv/src/main/java/qzui/domain/HttpJobDefinition.java
@@ -133,14 +133,14 @@ public class HttpJobDefinition extends AbstractJobDefinition {
             Optional<String> trustAllCerts;
             Optional<String> trustAllHosts;
             if (getHttpConfiguration() == null) {
-                trustAllCerts = Optional.fromNullable(System.getProperty(HttpConfiguration.TRUST_ALL_CERTS));
-                trustAllHosts = Optional.fromNullable(System.getProperty(HttpConfiguration.TRUST_ALL_HOSTS));
+                trustAllCerts = Optional.fromNullable(System.getProperty(HttpConfiguration.TRUST_ALL_CERTS_PROPERTY));
+                trustAllHosts = Optional.fromNullable(System.getProperty(HttpConfiguration.TRUST_ALL_HOSTS_PROPERTY));
             } else {
                 trustAllCerts = Optional.of(Boolean.toString(getHttpConfiguration().isTrustAllCerts()));
                 trustAllHosts = Optional.of(Boolean.toString(getHttpConfiguration().isTrustAllHosts()));
             }
-            dataMap.put(HttpConfiguration.TRUST_ALL_CERTS, trustAllCerts.or(Boolean.toString(false)));
-            dataMap.put(HttpConfiguration.TRUST_ALL_HOSTS, trustAllHosts.or(Boolean.toString(false)));
+            dataMap.put(HttpConfiguration.TRUST_ALL_CERTS_FIELD, trustAllCerts.or(Boolean.toString(false)));
+            dataMap.put(HttpConfiguration.TRUST_ALL_HOSTS_FIELD, trustAllHosts.or(Boolean.toString(false)));
         }
 
         @Override
@@ -182,10 +182,10 @@ public class HttpJobDefinition extends AbstractJobDefinition {
         }
 
         private void setSecurityParams(JobDataMap jobDataMap, HttpRequest request) {
-            if (jobDataMap.getBooleanFromString(HttpConfiguration.TRUST_ALL_HOSTS)) {
+            if (jobDataMap.getBooleanFromString(HttpConfiguration.TRUST_ALL_HOSTS_FIELD)) {
                 request.trustAllHosts();
             }
-            if (jobDataMap.getBooleanFromString(HttpConfiguration.TRUST_ALL_CERTS)) {
+            if (jobDataMap.getBooleanFromString(HttpConfiguration.TRUST_ALL_CERTS_FIELD)) {
                 request.trustAllCerts();
             }
         }


### PR DESCRIPTION
Some specific HTTP configuration flags could be set. 
Two ways to do that :
- Job specific : fill a configuration object (contained into a job descriptor)

```
{
  "type":"http",
  "name":"google-humans",
  "method":"GET",
  "url":"http://www.google.com/humans.txt",
  "triggers": [
        {"cron":"0/2 * * * * ?"}
  ],
  "httpConfiguration": {
        "trustAllHosts": true,
        "trustAllCerts": true,
  }
}
```
- Globally : define java properties set on Qzui runtime

```
-Dhttp.ssl.trustAllCerts=true -Dhttp.ssl.trustAllHosts=true
```

Note that the specific configuration overrides the global one.
